### PR TITLE
Remove uses of --show-current for backwards compat

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ See [Recover failed Git commit message](https://salferrarello.com/recover-failed
 
 ### `git track-origin-same-branch-name`
 
-Alias for `git branch --set-upstream-to=origin/$(git branch --show-current)`.
+Alias for `git branch --set-upstream-to=origin/$(git rev-parse --abbrev-ref HEAD)`.
 
 See [There is no tracking information for the current branch](https://salferrarello.com/there-is-no-tracking-information-for-the-current-branch/).
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ See [Git Previous Branch](https://salferrarello.com/git-previous-branch/).
 
 ### `git drb`
 
-Alias for `git push origin --delete $(git branch --show-current)` to delete the remote branch with the same name as the current branch from the remote **origin**.
+Alias for `git push origin --delete $(git rev-parse --abbrev-ref HEAD)` to delete the remote branch with the same name as the current branch from the remote **origin**.
 
 See [Deleting Remote Branches](https://git-scm.com/book/en/v2/Git-Branching-Remote-Branches#_delete_branches).
 

--- a/gitconfig
+++ b/gitconfig
@@ -26,7 +26,7 @@
 	}; f"
 	please = push --force-with-lease
 	recover-rejected-commit = "!f() { git "commit -e --file=$(git rev-parse --git-dir)/COMMIT_EDITMSG"; }; f"
-	track-origin-same-branch-name = !git branch --set-upstream-to=origin/$(git branch --show-current)
+	track-origin-same-branch-name = !git branch --set-upstream-to=origin/$(git rev-parse --abbrev-ref HEAD)
 [commit]
 	verbose = true
 [rebase]

--- a/gitconfig
+++ b/gitconfig
@@ -17,11 +17,11 @@
 		else \
 			target=\"$1...\"; \
 		fi; \
-		open \"$(git ls-remote --get-url $(git config --get branch.$(git branch --show-current).remote) \
+		open \"$(git ls-remote --get-url $(git config --get branch.$(git rev-parse --abbrev-ref HEAD).remote) \
 			| sed 's|git@github.com:\\(.*\\)$|https://github.com/\\1|' \
 			| sed 's|\\.git$||'; \
 		)/compare/$target$(\
-		git config --get branch.$(git branch --show-current).merge | cut -d '/' -f 3- \
+		git config --get branch.$(git rev-parse --abbrev-ref HEAD).merge | cut -d '/' -f 3- \
 		)?expand=1\"; \
 	}; f"
 	please = push --force-with-lease

--- a/gitconfig
+++ b/gitconfig
@@ -2,7 +2,7 @@
 	can-ff-merge = "!f() { \
 		[ -e "${1}" ] && echo "Missing branch name to merge" && exit 1; \
 		git "merge-base --is-ancestor \
-		$(git branch --show-current) ${1}" \
+		$(git rev-parse --abbrev-ref HEAD) ${1}" \
 		&& echo 'Yes, this can ff-merge' && exit 0 \
 		|| echo 'No, this can NOT ff-merge' && exit 1; \
 	}; f"

--- a/gitconfig
+++ b/gitconfig
@@ -7,7 +7,7 @@
 		|| echo 'No, this can NOT ff-merge' && exit 1; \
 	}; f"
 	d-b = branch -d @{-1}
-	drb = !git push origin --delete $(git branch --show-current)
+	drb = !git push origin --delete $(git rev-parse --abbrev-ref HEAD)
 	lg = log --color --graph --date=format:'%Y-%m-%d %H:%M:%S' --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%ad) %C(bold blue)<%an>%Creset'
 	open-pr-github = "!f() { \
 		: git branch ; \


### PR DESCRIPTION
Remove uses of "git branch --show-current", replacing them with "git rev-parse --abbrev-ref HEAD"

Both of these commands do the same thing, they return the name of the current branch.

However, "git branch --show-current" was only introduced in Git 2.22.0 (released 2019-06-07) meaning the command will fail on any version of Git earlier than this.

While overall, this project does not need to support old versions of Git this seems like an easy/low cost change to support older versions, without any negative impact on users running new versions of Git.

Resolves #1
Resolves #2 
Resolves #3
Resolves #4