### PR TITLE
Config to exclude commits from git blame

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,18 @@ See [There is no tracking information for the current branch](https://salferrare
 
 ## Configuration
 
+### blame.ignoreRevsFile
+
+Set `blame.ignoreRevsFile = .git-blame-ignore-revs` to ignore any commits listed in the optional repo file `.git-blame-ignore-revs` when doing a `git blame`.
+
+Additionally set `blame.markIgnoredLines = true` to "Mark lines that have a commit skipped using --ignore-rev with a `?`."
+
+And set `blame.markUnblamableLines = true` to "Mark lines that were added in a skipped commit with a `*`."
+
+See [A better git blame with --ignore-rev](https://michaelheap.com/git-ignore-rev/)
+
+**Note**: This only works on Git version `2.23` (released 2019-08-16) or greater.
+
 ### commit.verbose
 
 Set `commit.verbose = true` to display the changes in the comments of the commit.

--- a/gitconfig
+++ b/gitconfig
@@ -27,6 +27,12 @@
 	please = push --force-with-lease
 	recover-rejected-commit = "!f() { git "commit -e --file=$(git rev-parse --git-dir)/COMMIT_EDITMSG"; }; f"
 	track-origin-same-branch-name = !git branch --set-upstream-to=origin/$(git rev-parse --abbrev-ref HEAD)
+[blame]
+	ignoreRevsFile = .git-blame-ignore-revs
+	# Mark lines that have a commit skipped using --ignore-rev with a `?`
+	markIgnoredLines = true
+	# Mark lines that were added in a skipped commit with a `*`
+	markUnblamableLines = true
 [commit]
 	verbose = true
 [push]


### PR DESCRIPTION
If a repo has a .git-blame-ignore-revs file, any commits in that file will be excluded from the results of "git blame".

Additionally, this configuration modifies the git blame output so that:

- A "?" is added to the line if the output was modified by this ignoring
- A "*" is added if no commit can be associated with the line (because the commit that added the line is ignored)

See https://michaelheap.com/git-ignore-rev/