### PR TITLE
Add branch tab completion to can-ff-merge alias

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -1,5 +1,6 @@
 [alias]
 	can-ff-merge = "!f() { \
+		: git branch ; \
 		[ -e "${1}" ] && echo "Missing branch name to merge" && exit 1; \
 		git "merge-base --is-ancestor \
 		$(git rev-parse --abbrev-ref HEAD) ${1}" \


### PR DESCRIPTION
Adding this line tells Git to use branch names when doing tab completion.

See https://salferrarello.com/git-alias-tab-completion-for-functions/

Resolves #12