### PR TITLE
Add support for - to can-ff-merge alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### `git can-ff-merge [branch]`
 
-Alias to check if merging `[branch]` into the current branch can be done as a fast-forward merge. (i.e. checks if current branch is an ancestor of `[branch]`)
+Alias to check if merging `[branch]` into the current branch can be done as a fast-forward merge. (i.e. checks if current branch is an ancestor of `[branch]`). Note: This command supports using a single dash (`-`) to represent [the previous branch](https://salferrarello.com/git-previous-branch/).
 
 See [Check If We Can Do a Git Fast-Forward Merge](https://salferrarello.com/check-can-do-git-fast-forward-merge/).
 

--- a/gitconfig
+++ b/gitconfig
@@ -2,8 +2,13 @@
 	can-ff-merge = "!f() { \
 		: git branch ; \
 		[ -e "${1}" ] && echo "Missing branch name to merge" && exit 1; \
+		branch=$1; \
+		if [[ "$branch" == '-' ]]; \
+		then \
+			branch='@{-1}'; \
+		fi; \
 		git "merge-base --is-ancestor \
-		$(git rev-parse --abbrev-ref HEAD) ${1}" \
+		$(git rev-parse --abbrev-ref HEAD) ${branch}" \
 		&& echo 'Yes, this can ff-merge' && exit 0 \
 		|| echo 'No, this can NOT ff-merge' && exit 1; \
 	}; f"


### PR DESCRIPTION
Add support for checking if the previous branch can be merged into the current branch using a single dash (-) to represent the previous branch.

e.g.
git can-ff-merge -

Previously the slightly longer @{-1} (or the full branch name) had to be used instead of -.

See https://salferrarello.com/git-previous-branch/

Resolves #11