### PR TITLE
Show previous branch name when using -

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -21,7 +21,7 @@
 		branch=$1; \
 		if [[ "$branch" == '-' ]]; \
 		then \
-			branch='@{-1}'; \
+			branch=$(git rev-parse --abbrev-ref @{-1}); \
 		fi; \
 		git "merge-base --is-ancestor \
 		${branch} $(git rev-parse --abbrev-ref HEAD)" \


### PR DESCRIPTION
Display the previous branch name instead of @{-1} when using "git is-up-to-date-with -" to check if the
current branch is up to date with the previous branch

Before this Change

$ git is-up-to-date-with -
Yes, this branch is up to date with @{-1}

After this Change

$ git is-up-to-date-with -
Yes, this branch is up to date with main

Resolves #34